### PR TITLE
Set require_frame inside PressButton.

### DIFF
--- a/emulator/src/Peripheral/Keyboard.cpp
+++ b/emulator/src/Peripheral/Keyboard.cpp
@@ -216,6 +216,8 @@ namespace casioemu
 		else
 			button.pressed = true;
 
+		require_frame = true;
+
 		if (button.type == Button::BT_POWER && button.pressed && !old_pressed)
 			emulator.chipset.Reset();
 		if (button.type == Button::BT_BUTTON && button.pressed != old_pressed)
@@ -228,7 +230,6 @@ namespace casioemu
 		{
 			if (button.rect.x <= x && button.rect.y <= y && button.rect.x + button.rect.w > x && button.rect.y + button.rect.h > y)
 			{
-				require_frame = true;
 				PressButton(button, stick);
 				break;
 			}


### PR DESCRIPTION
Otherwise, pressing the keyboard buttons may sometimes not "highlight" the corresponding calculator keys. Try pressing [menu] then [shift].