### PR TITLE
Make the emulator render properly, even when start with `paused=`

### DIFF
--- a/emulator/src/Peripheral/Keyboard.cpp
+++ b/emulator/src/Peripheral/Keyboard.cpp
@@ -13,6 +13,7 @@ namespace casioemu
 	void Keyboard::Initialise()
 	{
 	    renderer = emulator.GetRenderer();
+	    require_frame = true;
 
 		interrupt_source.Setup(5, emulator);
 

--- a/emulator/src/Peripheral/Screen.cpp
+++ b/emulator/src/Peripheral/Screen.cpp
@@ -39,6 +39,7 @@ namespace casioemu
 			sprite_info[ix] = emulator.GetModelInfo(sprite_bitmap[ix].name);
 		
 		ink_colour = emulator.GetModelInfo("ink_colour");
+		require_frame = true;
 
 		screen_buffer = new uint8_t[0x0200];
 


### PR DESCRIPTION
One of the bugfixes for #10 .